### PR TITLE
fixed alternate currency barters

### DIFF
--- a/src/item/helpFunctions.js
+++ b/src/item/helpFunctions.js
@@ -134,9 +134,8 @@ function payMoney(profileData, body) {
                 output.data.items.del.push({"_id": item._id});
                 body.scheme_items[x].count = 0;
             }
-            else
-            {
-                // otherwise, it's probably just money so we can safely just grab the barter item tpl
+            else if (isMoneyTpl(item._tpl)){
+                // grab the barter item tpl when it is money barter
                 currencyTpl = item._tpl;
                 break;
             }

--- a/src/item/helpFunctions.js
+++ b/src/item/helpFunctions.js
@@ -118,22 +118,29 @@ function payMoney(profileData, body) {
 
     const sessionID = profileData.data[0].aid;
     const tmpTraderInfo = trader.get(body.tid, sessionID);
-    const currencyTpl = getCurrency(tmpTraderInfo.data.currency);
+    let currencyTpl = getCurrency(tmpTraderInfo.data.currency);
     let profileItems = profileData.data[0].Inventory.items;
 
     // delete barter things(not a money) from inventory
     if (body.Action === 'TradingConfirm') {
-        body.scheme_items.forEach((schemeItem, index) => {
-            let item = profileItems.find(inventoryItem => schemeItem.id === inventoryItem._id);
+        for(let x = 0; x < body.scheme_items.length; x++)
+        {
+            let item = profileItems.find(inventoryItem => body.scheme_items[x].id === inventoryItem._id);
 
             if (item !== undefined && !isMoneyTpl(item._tpl)) {
                 console.debug(`delete barter things. Item ID: ${item._id}`);
                 profileItems = profileItems.filter(inventoryItem => item._id !== inventoryItem._id);
 
                 output.data.items.del.push({"_id": item._id});
-                body.scheme_items[index].count = 0;
+                body.scheme_items[x].count = 0;
             }
-        });
+            else
+            {
+                // otherwise, it's probably just money so we can safely just grab the barter item tpl
+                currencyTpl = item._tpl;
+                break;
+            }
+        }
     }
 
     // find all items with currency _tpl id


### PR DESCRIPTION
Found when trying to purchase an item that has an alternate currency from the trader.
(Skier items that are priced with Euros)
(Peacekeeper dollar exchange will use dollars as the count of roubles when exchanging for dollars)

Changed it so that the _tpl used is not based on trader currency but the barter item _tpl. (This should only apply for money based barters)