### PR TITLE
Make server-side changes to support player scavs.

### DIFF
--- a/src/bots.js
+++ b/src/bots.js
@@ -157,6 +157,20 @@ function generatePlayerScav() {
 	let playerscav = generate({"conditions":[{"Role":"playerScav","Limit":1,"Difficulty":"normal"}]}).data;
 
 	playerscav[0].Info.Settings = {};
+	// delete secured containers because the bot loadouts may have them.
+	for (let item of playerscav[0].Inventory.items) {
+        if (item.slotId === "SecuredContainer") {
+            let idsToRemove = itm_hf.findAndReturnChildren(playerscav[0], item._id);
+            for (let itemId of idsToRemove) {
+            	for (let index in playerscav[0].Inventory.items) { //find correct item by id and delete it
+	                if (playerscav[0].Inventory.items[index]._id === itemId) {
+	                    playerscav[0].Inventory.items.splice(index, 1);  //remove item from tmplist
+	                }
+	            }
+            }
+        }
+    }
+
 	return playerscav[0];
 }
 

--- a/src/bots.js
+++ b/src/bots.js
@@ -109,6 +109,10 @@ function generateBot(botBase, role) {
 		}
 	}
 
+	if (role === "playerScav") {
+		type = "assault";
+	}
+
 	let botNode = getBotNode(type);
 
 	// generate bot
@@ -150,10 +154,9 @@ function generate(databots) {
 }
 
 function generatePlayerScav() {
-	let playerscav = generate({"conditions":[{"Role":"assault","Limit":1,"Difficulty":"normal"}]}).data;
+	let playerscav = generate({"conditions":[{"Role":"playerScav","Limit":1,"Difficulty":"normal"}]}).data;
 
 	playerscav[0].Info.Settings = {};
-	playerscav[0]._id = "5c71b934354682353958e983";
 	return playerscav[0];
 }
 

--- a/src/caching/_route.js
+++ b/src/caching/_route.js
@@ -282,6 +282,7 @@ function others() {
     filepaths.profile.userbuilds = "db/profile/userbuilds.json";
     filepaths.user.profiles.list = "user/profiles/list.json";
     filepaths.user.profiles.character = "user/profiles/__REPLACEME__/character.json";
+    filepaths.user.profiles.scav = "user/profiles/__REPLACEME__/scav.json";
     filepaths.user.profiles.storage = "user/profiles/__REPLACEME__/storage.json";
     filepaths.user.profiles.userbuilds = "user/profiles/__REPLACEME__/userbuilds.json";
     filepaths.user.config = "user/server.config.json";

--- a/src/item/_move.js
+++ b/src/item/_move.js
@@ -21,20 +21,46 @@ function moveItem(tmpList, body) {
     }
     //cartriges handler end
 
-    for (let item of tmpList.data[0].Inventory.items) {
-        if (item._id && item._id === body.item) {
-            item.parentId = body.to.id;
-            item.slotId = body.to.container;
-            if (typeof body.to.location !== "undefined") {
-                item.location = body.to.location;
-            } else {
-                if (item.location) {
-                    delete item.location;
+    if (typeof body.fromOwner !== 'undefined' && body.fromOwner.id === tmpList.data[1]._id) {
+        let mainItems = tmpList.data[0].Inventory.items;
+        let scavItems = tmpList.data[1].Inventory.items;
+        let idsToMove = itm_hf.findAndReturnChildren(tmpList.data[1], body.item);
+        for (let itemId of idsToMove) {
+            for (let item of scavItems) {
+                if (item._id && item._id === itemId) {
+                    if (itemId === body.item) {
+                        item.parentId = body.to.id;
+                        item.slotId = body.to.container;
+                        if (typeof body.to.location !== "undefined") {
+                            item.location = body.to.location;
+                        } else {
+                            if (item.location) {
+                                delete item.location;
+                            }
+                        }
+                    }
+                    mainItems.push(item);
                 }
             }
+        }
+        profile.setCharacterData(tmpList);
+        return output;
+    } else {
+        for (let item of tmpList.data[0].Inventory.items) {
+            if (item._id && item._id === body.item) {
+                item.parentId = body.to.id;
+                item.slotId = body.to.container;
+                if (typeof body.to.location !== "undefined") {
+                    item.location = body.to.location;
+                } else {
+                    if (item.location) {
+                        delete item.location;
+                    }
+                }
 
-            profile.setCharacterData(tmpList);
-            return output;
+                profile.setCharacterData(tmpList);
+                return output;
+            }
         }
     }
 
@@ -43,8 +69,9 @@ function moveItem(tmpList, body) {
 
 /* Remove Item
 * Deep tree item deletion / Delets main item and all sub items with sub items ... and so on.
+* Profile index: 0 = main profile, 1 = scav profile
 * */
-function removeItem(tmpList, body, output = item.getOutput()) {
+function removeItem(tmpList, body, output = item.getOutput(), profileIndex = 0) {
     // -> Deletes item and its all child completly - now works
 	if (output == ""){
 		item.resetOutput();
@@ -55,19 +82,23 @@ function removeItem(tmpList, body, output = item.getOutput()) {
 
     //Find the item and all of it's relates
     if (toDo[0] !== undefined && toDo[0] !== null && toDo[0] !== "undefined") {
-        let ids_toremove = itm_hf.findAndReturnChildren(tmpList, toDo[0]); //get all ids related to this item, +including this item itself
+        let ids_toremove = itm_hf.findAndReturnChildren(tmpList.data[profileIndex], toDo[0]); //get all ids related to this item, +including this item itself
 
         for (let i in ids_toremove) { //remove one by one all related items and itself
             output.data.items.del.push({"_id": ids_toremove[i]}); // Tell client to remove this from live game
 
-            for (let a in tmpList.data[0].Inventory.items) {	//find correct item by id and delete it
-                if (tmpList.data[0].Inventory.items[a]._id === ids_toremove[i]) {
-                    tmpList.data[0].Inventory.items.splice(a, 1);  //remove item from tmplist
+            for (let a in tmpList.data[profileIndex].Inventory.items) {	//find correct item by id and delete it
+                if (tmpList.data[profileIndex].Inventory.items[a]._id === ids_toremove[i]) {
+                    tmpList.data[profileIndex].Inventory.items.splice(a, 1);  //remove item from tmplist
                 }
             }
         }
 
-        profile.setCharacterData(tmpList); //save tmplist to profile
+        if (profileIndex === 1) {
+            profile.setScavData(tmpList); // save scav profile
+        } else {
+            profile.setCharacterData(tmpList); //save tmplist to profile
+        }
         return output;
     } else {
         logger.logError("item id is not vaild");
@@ -81,7 +112,7 @@ function removeInsurance(tmpList, body) {
     
     //Find the item and all of it's relates
     if (toDo[0] !== undefined && toDo[0] !== null && toDo[0] !== "undefined") {
-        let ids_toremove = itm_hf.findAndReturnChildren(tmpList, toDo[0]); //get all ids related to this item, +including this item itself
+        let ids_toremove = itm_hf.findAndReturnChildren(tmpList.data[0], toDo[0]); //get all ids related to this item, +including this item itself
 
         for (let i in ids_toremove) { //remove one by one all related items and itself
             for (let a in tmpList.data[0].Inventory.items) {	//find correct item by id and delete it

--- a/src/item/helpFunctions.js
+++ b/src/item/helpFunctions.js
@@ -418,7 +418,7 @@ function getSize(itemtpl, itemID, InventoryItem) { // -> Prepares item Width and
 function findAndReturnChildren(tmpList, itemid) {
     let list = [];
 
-    for (let childitem of tmpList.data[0].Inventory.items) {
+    for (let childitem of tmpList.Inventory.items) {
         if (childitem.parentId === itemid) {
             list.push.apply(list, findAndReturnChildren(tmpList, childitem._id));
         }

--- a/src/profile.js
+++ b/src/profile.js
@@ -120,7 +120,6 @@ function saveProfileProgress(offRaidData) {
     // replace data
     // if isPlayerScav is true, then offRaidProfile points to a scav profile
     const isPlayerScav = offRaidData.isPlayerScav;
-    console.log('is this scav? ' + isPlayerScav);
     if (!isPlayerScav) {
         tmpList.data[0].Info.Level = offRaidProfile.Info.Level;
         tmpList.data[0].Skills = offRaidProfile.Skills;

--- a/src/response.js
+++ b/src/response.js
@@ -54,7 +54,7 @@ const staticRoutes = {
     "/client/match/group/exit_from_menu": nullResponse,
     "/client/match/exit": nullResponse,
     "/client/match/updatePing": nullResponse,
-    "/client/game/profile/savage/regenerate": nullResponse,
+    "/client/game/profile/savage/regenerate": regenerateScav,
     "/client/mail/dialog/list": getMailDialogList,
     "/client/mail/dialog/view": getMailDialogView,
     "/client/mail/dialog/info": getMailDialogInfo,
@@ -165,6 +165,13 @@ function getProfileData(url, info) {
     }
 
     return JSON.stringify(responseData);
+}
+
+function regenerateScav(url, info) {
+    let response = {err: 0, errmsg: null, data: []};
+    response.data.push(profile.generateScavProfile());
+
+    return JSON.stringify(response);
 }
 
 function selectProfile(url, info) {


### PR DESCRIPTION
This change reworks scav generation so that they are saved to a json file like character.json. Instead of generating a scav every time profiles are loaded, the server will now generate a scav when it's explicitly requested to do so by the client (previously, this was a no-op). This means that one generated scav will stay with you until he dies or escapes.

This change also introduces changes to the item function to support inventory transfer at the end of a successful raid from a player scav. Some item functions have been refactored to take in a single profile as the argument instead of a list of two profiles (main + scav).

Profile saving function also required some modifications.

