### PR TITLE
Fixed preset ragfair buying

### DIFF
--- a/src/item/_trade.js
+++ b/src/item/_trade.js
@@ -97,7 +97,17 @@ function confirmRagfairTrading(tmpList, body) {
         body.scheme_id = 0;
         body.scheme_items = offer.items;
 
-        output = confirmTrading(tmpList, body);
+        let tmpOutput = confirmTrading(tmpList, body);
+
+        // this compiles all the offers that will eventually be sent back into one
+        // response to handle the ragfair purchase (multiple offer purchase ie. preset purchases)
+        for (let item of tmpOutput.data.items.new) {
+            output.data.items.new.push(item);
+        }
+
+        for (let item of tmpOutput.data.items.change) {
+            output.data.items.change.push(item);
+        }
     }
     return output;
 }


### PR DESCRIPTION
change array was empty when writing the response (output)
Items should now appear after purchasing from ragfair using the "purchase all" option in the preset menu.