### PR TITLE
Always lower-case map name

### DIFF
--- a/src/server/_start.js
+++ b/src/server/_start.js
@@ -149,7 +149,7 @@ function sendResponse(req, resp, body, sessionID) {
     }
 
     if (output === "MAP") {
-        let mapName = req.url.replace("/api/location/", "");
+        let mapName = req.url.replace("/api/location/", "").toLowerCase();
         let map = map_f.get(mapName);
         header_f.sendTextJson(resp, map);
         return;
@@ -184,7 +184,7 @@ function handleRequest(req, resp) {
             });
         });
     }
-    
+
     if (req.method === "PUT") { // offline profile saving
         logger.logWarning("Put!");
 
@@ -205,7 +205,7 @@ function handleRequest(req, resp) {
             // unpack data
             zlib.inflate(data, function (err, body) {
                 let jsonData = json.parse((body !== undefined) ? body.toString() : "{}");
-            
+
                 logger.logRequest("[" + sessionID + "][" + IP + "] " + req.url + " -> " + jsonData);
                 sendResponse(req, resp, jsonData, sessionID);
             });
@@ -217,7 +217,7 @@ function handleRequest(req, resp) {
     }
 }
 
-function start() {  
+function start() {
     // set the ip
     if (settings.server.generateIp == true) {
         ip = utility.getLocalIpAddress();


### PR DESCRIPTION
Some maps are called with non-lowercase names in API, while array of maps is in lowercase.

Example, selected Interchange, click Next, Next, enable PvE & Bosses, Next, Insure items Next, Ready

Game eventually loads into an empty map

```
[NaN][127.0.0.1] /api/location/Interchange
[ERROR] Server: 1.0.0
[ERROR] Game: 0.12.2.5485
[ERROR] Trace:
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.get (C:\Games\EscapeFromTarkov\EmuTarkov-Server\src\response\_map.js:7:30)
    at sendResponse (C:\Games\EscapeFromTarkov\EmuTarkov-Server\src\server\_start.js:153:25)
    at handleRequest (C:\Games\EscapeFromTarkov\EmuTarkov-Server\src\server\_start.js:173:9)
    at Server.https.createServer (C:\Games\EscapeFromTarkov\EmuTarkov-Server\src\server\_start.js:234:9)
    at Server.emit (events.js:189:13)
    at parserOnIncoming (_http_server.js:672:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)
[INFO] Finished Dumping Error
```

While `filepaths.maps` is `bigmap,develop,factory4_day,factory4_night,hideout,interchange,laberatory,rezervbase,shoreline,woods`

Fix by forcing lower-case
```js
    if (output === "MAP") {
        let mapName = req.url.replace("/api/location/", "").toLowerCase();
        let map = map_f.get(mapName);
        header_f.sendTextJson(resp, map);
        return;
    }
```

Hence map fails to load.