### PR TITLE
Spa Tour Part 3 & Punisher Part 3 Counter Fixes

### DIFF
--- a/db/quests/59c512ad86f7741f0d09de9b.json
+++ b/db/quests/59c512ad86f7741f0d09de9b.json
@@ -132,7 +132,7 @@
 			{
 				"_parent": "CounterCreator",
 				"_props": {
-					"value": "50",
+					"value": "25",
 					"type": "Elimination",
 					"counter": {
 						"id": "59674d5186f27446b872d5f6",

--- a/db/quests/5a0327ba86f77456b9154236.json
+++ b/db/quests/5a0327ba86f77456b9154236.json
@@ -200,7 +200,7 @@
 					"target": [
 						"59e358a886f7741776641ac3"
 					],
-					"value": "3",
+					"value": "2",
 					"minDurability": 0,
 					"index": 2,
 					"parentId": "",
@@ -216,7 +216,7 @@
 					"target": [
 						"59e358a886f7741776641ac3"
 					],
-					"value": "3",
+					"value": "2",
 					"minDurability": 0,
 					"index": 3,
 					"parentId": "",
@@ -233,7 +233,7 @@
 					"target": [
 						"59e35cbb86f7741778269d83"
 					],
-					"value": "3",
+					"value": "2",
 					"minDurability": 0,
 					"index": 4,
 					"parentId": "",
@@ -249,7 +249,7 @@
 					"target": [
 						"59e35cbb86f7741778269d83"
 					],
-					"value": "3",
+					"value": "2",
 					"minDurability": 0,
 					"index": 5,
 					"parentId": "",
@@ -266,7 +266,7 @@
 					"target": [
 						"59e3556c86f7741776641ac2"
 					],
-					"value": "3",
+					"value": "2",
 					"minDurability": 0,
 					"index": 6,
 					"parentId": "",
@@ -282,7 +282,7 @@
 					"target": [
 						"59e3556c86f7741776641ac2"
 					],
-					"value": "3",
+					"value": "2",
 					"minDurability": 0,
 					"index": 7,
 					"parentId": "",


### PR DESCRIPTION
Fix Spa Tour Part 3 requiring 3 Clin Wiper, Corrugated Hose, and Ox Bleach instead of 2.

https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_3

Fix Punisher Part 3 requiring 50 Scav Kills instead of 25.

https://escapefromtarkov.gamepedia.com/The_Punisher_-_Part_3