### PR TITLE
Money from sells won't go into the character's equipment

### DIFF
--- a/src/item/helpFunctions.js
+++ b/src/item/helpFunctions.js
@@ -199,6 +199,18 @@ function findMoney(by, pmcData, barter_itemID) { // find required items to take 
     return itemsArray;
 }
 
+/*
+* Finds an item given its id using linear search
+*/
+function findItemById(items, id) {
+    for (let item of items) {
+        if (item._id === id) {
+            return item;
+        }
+    }
+    return false;
+}
+
 /* Recursively checks if the given item is
 * inside the stash, that is it has the stash as
 * ancestor with slotId=hideout
@@ -209,7 +221,10 @@ function isItemInStash(pmcData, item) {
         if (container.parentId === pmcData.Inventory.stash && container.slotId === "hideout") {
             return true;
         }
-        container = container.parentId;
+        container = findItemById(pmcData.Inventory.items, container.parentId);
+        if (!container) {
+            break;
+        }
     }
 
     return false;

--- a/src/item/helpFunctions.js
+++ b/src/item/helpFunctions.js
@@ -199,6 +199,22 @@ function findMoney(by, pmcData, barter_itemID) { // find required items to take 
     return itemsArray;
 }
 
+/* Recursively checks if the given item is
+* inside the stash, that is it has the stash as
+* ancestor with slotId=hideout
+*/
+function isItemInStash(pmcData, item) {
+	let container = item;
+	while (typeof container.parentId != "undefined") {
+		if (container.parentId === pmcData.Inventory.stash && container.slotId === "hideout") {
+			return true;
+		}
+		container = container.parentId;
+	}
+
+	return false;
+}
+
 /* receive money back after selling
 * input: pmcData, numberToReturn, request.body,
 * output: none (output is sended to item.js, and profile is saved to file)
@@ -208,6 +224,12 @@ function getMoney(pmcData, amount, body, output, sessionID) {
     let currency = getCurrency(tmpTraderInfo.data.currency);
     let calcAmount = fromRUB(inRUB(amount, currency), currency);
     let skip = false;
+	let maxStackSize = 50000;
+
+    // adjust maxStackSize for RUN
+    if (currency === "5449016a4bdc2d6f028b456f") {
+        maxStackSize = 500000;
+    }
 
     for (let item of pmcData.Inventory.items) {
         // item is not currency
@@ -215,14 +237,19 @@ function getMoney(pmcData, amount, body, output, sessionID) {
             continue;
         }
 
+        // item is not in the stash
+        if (!isItemInStash(pmcData, item)) {
+            continue;
+        }
+
         // too much money for a stack
-        if (item.upd.StackObjectsCount + calcAmount > 500000) {
+        if (item.upd.StackObjectsCount + calcAmount > maxStackSize) {
             // calculate difference
             let tmp = item.upd.StackObjectsCount;
-            let difference = 500000 - tmp;
+            let difference = maxStackSize - tmp;
 
             // make stack max money, then look further
-            item.upd.StackObjectsCount = 500000;
+            item.upd.StackObjectsCount = maxStackSize;
             output.data.items.change.push(item);
             calcAmount -= difference;
             continue;

--- a/src/item/helpFunctions.js
+++ b/src/item/helpFunctions.js
@@ -204,15 +204,15 @@ function findMoney(by, pmcData, barter_itemID) { // find required items to take 
 * ancestor with slotId=hideout
 */
 function isItemInStash(pmcData, item) {
-	let container = item;
-	while (typeof container.parentId != "undefined") {
-		if (container.parentId === pmcData.Inventory.stash && container.slotId === "hideout") {
-			return true;
-		}
-		container = container.parentId;
-	}
+    let container = item;
+    while (typeof container.parentId != "undefined") {
+        if (container.parentId === pmcData.Inventory.stash && container.slotId === "hideout") {
+            return true;
+        }
+        container = container.parentId;
+    }
 
-	return false;
+    return false;
 }
 
 /* receive money back after selling
@@ -224,7 +224,7 @@ function getMoney(pmcData, amount, body, output, sessionID) {
     let currency = getCurrency(tmpTraderInfo.data.currency);
     let calcAmount = fromRUB(inRUB(amount, currency), currency);
     let skip = false;
-	let maxStackSize = 50000;
+    let maxStackSize = 50000;
 
     // adjust maxStackSize for RUN
     if (currency === "5449016a4bdc2d6f028b456f") {


### PR DESCRIPTION
… and won't push existing stacks over their max value.

Hi,
Here's an attempt at fixing bug #199 (if confirmed). To make things simpler and more sensible, money from sells should now be forced into the player's stash. The stack limit depends on the currency (500k for RUB, 50k for EUR/USD).
Let me know if you think using the character's equipment inventory is still a viable option.

Note: this should fix existing stacks not going over the limit, but it seems that the rest of the function (at the _addedMoney_ label) can still create a single stack of all the money that could not fit into an existing stack. For example, selling the gamma container for a few million RUB will end up having a huge stack of cash in the stash. While still a problem, the player can then ctrl+click the stack to split it (which is impossible if the stack is not in the stash). If the player doesn't split his big stack, then problems may arise soon or later. So maybe splitting that remaining cash is also a good idea.

If only the game client does not freak out with big stacks ...