### PR TITLE
Small optimization: put a constant out of a loop

### DIFF
--- a/src/classes/helpfunc.js
+++ b/src/classes/helpfunc.js
@@ -239,6 +239,7 @@ function getMoney(pmcData, amount, body, output, sessionID) {
     let tmpTraderInfo = trader_f.traderServer.getTrader(body.tid, sessionID);
     let currency = getCurrency(tmpTraderInfo.data.currency);
     let calcAmount = fromRUB(inRUB(amount, currency), currency);
+    let maxStackSize = (json.parse(json.read(filepaths.items[currency])))._props.StackMaxSize;
     let skip = false;
 
     for (let item of pmcData.Inventory.items) {
@@ -251,9 +252,6 @@ function getMoney(pmcData, amount, body, output, sessionID) {
         if (!isItemInStash(pmcData, item)) {
             continue;
         }
-
-        // too much money for a stack
-        let maxStackSize = (json.parse(json.read(filepaths.items[item._tpl])))._props.StackMaxSize;
 
         if (item.upd.StackObjectsCount + calcAmount > maxStackSize) {
             // calculate difference


### PR DESCRIPTION
That's only a tiny contribution. In helpfunc::getMoney() for-loop, item._tpl is always equal to currency which is constant, so there's no need to fetch item files to recompute maxStackSize every time.
