### PR TITLE
Should fix some quest reward items not being given

### DIFF
--- a/src/classes/dialogue.js
+++ b/src/classes/dialogue.js
@@ -83,7 +83,7 @@ class DialogueServer {
 
 			for (let reward of rewards) {
 				reward._id = utility.generateNewItemId();
-				if (reward.slotId === "hideout") {
+				if (!reward.hasOwnProperty("slotId") || reward.slotId === "hideout") {
 					reward.parentId = stashId;
 					reward.slotId = "main";
 				}


### PR DESCRIPTION
For some quests, I never get the reward items. The dialogue entry is
always marked as received.

The reason for this seems to be parentId and slotId are missing for these
items. Example: quest 5d25cf2686f77443e75488d4 (Jaeger-Tough Guy)
rewards.Success.items are missing those keys. As a result, dialogue.json
is missing them as well and the message won't display the reward.

A quick fix for this is to mimic what's already done for orphaned items.
Doing so, the items get the trader stash as parent and are ready to
be collected.