### PR TITLE
Flea Market weapons

### DIFF
--- a/src/classes/helpfunc.js
+++ b/src/classes/helpfunc.js
@@ -602,12 +602,13 @@ function replaceIDs(pmcData, items) {
 }
 
 //TODO change templates.data.Items to a dictionary to avoid all those loops
-function getItemPrice(templateId) {
+function getTemplateItem(templateId) {
     for (let template of templates.data.Items) {
         if (template.Id === templateId) {
-            return template.Price;
+            return template;
         }
     }
+    return false;
 }
 
 function clone(x) {
@@ -629,5 +630,5 @@ module.exports.findAndReturnChildrenByItems = findAndReturnChildrenByItems;
 module.exports.isDogtag = isDogtag;
 module.exports.isNotSellable = isNotSellable;
 module.exports.replaceIDs = replaceIDs;
-module.exports.getItemPrice = getItemPrice;
+module.exports.getTemplateItem = getTemplateItem;
 module.exports.clone = clone;

--- a/src/classes/helpfunc.js
+++ b/src/classes/helpfunc.js
@@ -601,6 +601,19 @@ function replaceIDs(pmcData, items) {
     return items;
 }
 
+//TODO change templates.data.Items to a dictionary to avoid all those loops
+function getItemPrice(templateId) {
+    for (let template of templates.data.Items) {
+        if (template.Id === templateId) {
+            return template.Price;
+        }
+    }
+}
+
+function clone(x) {
+    return json.parse(json.stringify(x));
+}
+
 module.exports.recheckInventoryFreeSpace = recheckInventoryFreeSpace;
 module.exports.getCurrency = getCurrency;
 module.exports.inRUB = inRUB;
@@ -616,3 +629,5 @@ module.exports.findAndReturnChildrenByItems = findAndReturnChildrenByItems;
 module.exports.isDogtag = isDogtag;
 module.exports.isNotSellable = isNotSellable;
 module.exports.replaceIDs = replaceIDs;
+module.exports.getItemPrice = getItemPrice;
+module.exports.clone = clone;

--- a/src/classes/hideout.js
+++ b/src/classes/hideout.js
@@ -228,9 +228,14 @@ function HideoutTakeProduction(pmcData, body, sessionID) {
 		}
 
 		// create item and throw it into profile
+        let id = hideoutProduction.data[receipe].endProduct;
+        if (preset_f.itemPresets.hasPreset(id)) {
+            // replace the base item with its main preset
+            id = preset_f.itemPresets.getStandardPreset(id)._id;
+        }
 		let newReq = {};
 
-		newReq.item_id = hideoutProduction.data[receipe].endProduct;
+		newReq.item_id = id
 		newReq.count = hideoutProduction.data[receipe].count;
 		newReq.tid = "ragfair";
 		return move_f.addItem(pmcData, newReq, output, sessionID, true);	

--- a/src/classes/move.js
+++ b/src/classes/move.js
@@ -355,9 +355,16 @@ function addItem(pmcData, body, output, sessionID, foundInRaid = false) {
     let PlayerStash = itm_hf.getPlayerStash(sessionID);
     let stashY = PlayerStash[1];
     let stashX = PlayerStash[0];
-    let tmpTraderAssort = trader_f.traderServer.getAssort(body.tid);
+    let items;
+    if (body.item_id in globals.data.ItemPresets) {
+        items = globals.data.ItemPresets[body.item_id]._items;
+        body.item_id = items[0]._id;
+    }
+    else {
+        items = trader_f.traderServer.getAssort(body.tid).data.items;
+    }
 
-    for (let item of tmpTraderAssort.data.items) {
+    for (let item of items) {
         if (item._id === body.item_id) {
             let MaxStacks = 1;
             let StacksValue = [];
@@ -390,7 +397,7 @@ function addItem(pmcData, body, output, sessionID, foundInRaid = false) {
                 pmcData = profile_f.profileServer.getPmcProfile(sessionID);
 
                 let StashFS_2D = itm_hf.recheckInventoryFreeSpace(pmcData, sessionID);
-                let ItemSize = itm_hf.getSize(item._tpl, item._id, tmpTraderAssort.data.items);
+                let ItemSize = itm_hf.getSize(item._tpl, item._id, items);
                 let tmpSizeX = ItemSize[0];
                 let tmpSizeY = ItemSize[1];
 
@@ -454,16 +461,16 @@ function addItem(pmcData, body, output, sessionID, foundInRaid = false) {
                                     break;
                                 }
 
-                                for (let tmpKey in tmpTraderAssort.data.items) {
-                                    if (tmpTraderAssort.data.items[tmpKey].parentId && tmpTraderAssort.data.items[tmpKey].parentId === toDo[0][0]) {
+                                for (let tmpKey in items) {
+                                    if (items[tmpKey].parentId && items[tmpKey].parentId === toDo[0][0]) {
                                         newItem = utility.generateNewItemId();
 
-                                        let SlotID = tmpTraderAssort.data.items[tmpKey].slotId;
+                                        let SlotID = items[tmpKey].slotId;
 
                                         if (SlotID === "hideout") {
                                             output.data.items.new.push({
                                                 "_id": newItem,
-                                                "_tpl": tmpTraderAssort.data.items[tmpKey]._tpl,
+                                                "_tpl": items[tmpKey]._tpl,
                                                 "parentId": toDo[0][1],
                                                 "slotId": SlotID,
                                                 "location": {"x": x, "y": y, "r": "Horizontal"},
@@ -472,16 +479,16 @@ function addItem(pmcData, body, output, sessionID, foundInRaid = false) {
 
                                             pmcData.Inventory.items.push({
                                                 "_id": newItem,
-                                                "_tpl": tmpTraderAssort.data.items[tmpKey]._tpl,
+                                                "_tpl": items[tmpKey]._tpl,
                                                 "parentId": toDo[0][1],
-                                                "slotId": tmpTraderAssort.data.items[tmpKey].slotId,
+                                                "slotId": items[tmpKey].slotId,
                                                 "location": {"x": x, "y": y, "r": "Horizontal"},
                                                 "upd": upd
                                             });
                                         } else {
                                             output.data.items.new.push({
                                                 "_id": newItem,
-                                                "_tpl": tmpTraderAssort.data.items[tmpKey]._tpl,
+                                                "_tpl": items[tmpKey]._tpl,
                                                 "parentId": toDo[0][1],
                                                 "slotId": SlotID,
                                                 "upd": upd
@@ -489,14 +496,14 @@ function addItem(pmcData, body, output, sessionID, foundInRaid = false) {
 
                                             pmcData.Inventory.items.push({
                                                 "_id": newItem,
-                                                "_tpl": tmpTraderAssort.data.items[tmpKey]._tpl,
+                                                "_tpl": items[tmpKey]._tpl,
                                                 "parentId": toDo[0][1],
-                                                "slotId": tmpTraderAssort.data.items[tmpKey].slotId,
+                                                "slotId": items[tmpKey].slotId,
                                                 "upd": upd
                                             });
                                         }
 
-                                        toDo.push([tmpTraderAssort.data.items[tmpKey]._id, newItem]);
+                                        toDo.push([items[tmpKey]._id, newItem]);
                                     }
                                 }
 

--- a/src/classes/preset.js
+++ b/src/classes/preset.js
@@ -1,0 +1,50 @@
+"use strict";
+
+class ItemPresets {
+
+    constructor() {
+        const presets = Object.values(globals.data.ItemPresets);
+        const reverse = {};
+        for (const p of presets) {
+            let tpl = p._items[0]._tpl;
+            if (!reverse.hasOwnProperty(tpl)) {
+                reverse[tpl] = [];
+            }
+            reverse[tpl].push(p._id);
+        }
+        this.lookup = reverse;
+    }
+
+    hasPreset(templateId) {
+        return this.lookup.hasOwnProperty(templateId);
+    }
+
+    getPresets(templateId) {
+        if (!this.hasPreset(templateId)) {
+            return [];
+        }
+        const presets = [];
+        const ids = this.lookup[templateId];
+        for (const id of ids) {
+            console.log("id = " + id);
+            presets.push(globals.data.ItemPresets[id]);
+        }
+        return presets;
+    }
+
+    getStandardPreset(templateId) {
+        if (!this.hasPreset(templateId)) {
+            return false;
+        }
+        const allPresets = this.getPresets(templateId);
+        for (const p of allPresets) {
+            if (p.hasOwnProperty("_encyclopedia")) {
+                return p;
+            }
+        }
+        return allPresets[0];
+    }
+
+}
+
+module.exports.itemPresets = new ItemPresets();

--- a/src/classes/preset.js
+++ b/src/classes/preset.js
@@ -15,6 +15,10 @@ class ItemPresets {
         this.lookup = reverse;
     }
 
+    isPreset(id) {
+        return globals.data.ItemPresets.hasOwnProperty(id);
+    }
+
     hasPreset(templateId) {
         return this.lookup.hasOwnProperty(templateId);
     }
@@ -26,7 +30,6 @@ class ItemPresets {
         const presets = [];
         const ids = this.lookup[templateId];
         for (const id of ids) {
-            console.log("id = " + id);
             presets.push(globals.data.ItemPresets[id]);
         }
         return presets;

--- a/src/classes/ragfair.js
+++ b/src/classes/ragfair.js
@@ -116,12 +116,9 @@ function getLinkedSearchList(linkedSearchId, response) {
         for (let itemSlot of itemLink._props.Slots) {
             for (let itemSlotFilter of itemSlot._props.filters) {
                 for (let mod of itemSlotFilter.Filter) {
-                    for (let item of templates.data.Items) {
-                        if (item.Id === mod) {
-                            tableOfItems[mod] = item.Price;
-                            response.data.categories[mod] = 1;
-                        }
-                    }
+                    let item = itm_hf.getTemplateItem(mod);
+                    tableOfItems[mod] = item.Price;
+                    response.data.categories[mod] = 1;
                 }
             }
         }
@@ -129,12 +126,9 @@ function getLinkedSearchList(linkedSearchId, response) {
 
     if ("Chambers" in itemLink._props) {
         for (let patron of itemLink._props.Chambers[0]._props.filters[0].Filter) {
-            for (let item of templates.data.Items) {
-                if (item.Id === patron) {
-                    tableOfItems[patron] = item.Price;
-                    response.data.categories[patron] = 1;
-                }
-            }
+            let item = itm_hf.getTemplateItem(patron);
+            tableOfItems[patron] = item.Price;
+            response.data.categories[patron] = 1;
         }
     }
 
@@ -190,12 +184,8 @@ function getCategoryList(handbookId) {
         if (isCateg === false) {
             for (let curItem in items.data) {
                 if (curItem === handbookId) {
-                    for (let item of templates.data.Items) {
-                        if (item.Id === handbookId) {
-                            tableOfItems[curItem] = item.Price;
-                        }
-                    }
-
+                    let item = itm_hf.getTemplateItem(handbookId);
+                    tableOfItems[curItem] = item.Price;
                     break;
                 }
             }
@@ -209,13 +199,8 @@ function createOfferFromBuild(buildItems,response) {
     for (var itemFromBuild in buildItems) {
         for (let curItem in items.data) {
             if (curItem === itemFromBuild) {
-                for (let item of templates.data.Items) {
-                    if (item.Id === itemFromBuild) {
-                        response.data.offers.push(...createOffer(curItem, item.Price));
-                        break;
-                    }
-                }
-
+                let item = itm_hf.getTemplateItem(itemFromBuild);
+                response.data.offers.push(...createOffer(curItem, item.Price));
                 break;
             }
         }
@@ -237,7 +222,7 @@ function createOffer(template, price) {
             let rub = 0;
             for (let it of mods) {
                 // TODO handles cartridges if it *really* matters
-                rub += itm_hf.getItemPrice(it._tpl);
+                rub += itm_hf.getTemplateItem(it._tpl).Price;
             }
             mods[0].upd = mods[0].upd || {}; // append the stack count
             mods[0].upd.StackObjectsCount = offerBase.items[0].upd.StackObjectsCount;

--- a/src/classes/ragfair.js
+++ b/src/classes/ragfair.js
@@ -87,7 +87,7 @@ function getOffers(request) {
         let offers_tpl = getLinkedSearchList(request.linkedSearchId,response);
         let offers = [];
 
-        for (let price in offers) {
+        for (let price in offers_tpl) {
             offers.push(...createOffer(price, offers_tpl[price]));
         }
 

--- a/src/classes/ragfair.js
+++ b/src/classes/ragfair.js
@@ -227,8 +227,18 @@ function createOfferFromBuild(buildItems,response) {
 function createOffer(template, price) {
     let offerBase = json.parse(json.read(filepaths.ragfair.offer));
 
-    offerBase._id = template;
-    offerBase.items[0]._tpl = template;
+    if (preset_f.itemPresets.hasPreset(template)) {
+        let preset = preset_f.itemPresets.getStandardPreset(template);
+        let mods = preset._items;
+        offerBase._id = preset._id;
+        offerBase.root = mods[0]._id;
+        mods[0].upd = offerBase.items[0].upd;
+        offerBase.items = mods;
+    }
+    else {
+        offerBase._id = template;
+        offerBase.items[0]._tpl = template;
+    }
     offerBase.requirements[0].count = Math.round(price * settings.gameplay.trading.ragfairMultiplier);
 	//offerBase.startTime = utility.getTimestamp() - 1000;
     //offerBase.endTime = utility.getTimestamp() + 43200;

--- a/src/loadorder.json
+++ b/src/loadorder.json
@@ -24,6 +24,7 @@
         "repair_f": "src/classes/repair.js",
         "insurance_f": "src/classes/insurance.js",
         "trader_f": "src/classes/trader.js",
+        "preset_f": "src/classes/preset.js",
         "ragfair_f": "src/classes/ragfair.js",
         "weather_f": "src/classes/weather.js",
         "location_f": "src/classes/location.js"


### PR DESCRIPTION
Here's another attempt at fixing the Flea Market (and the hideout).

I tried to avoid modifying too much code. We can then improve and optimize the code if that merges.
So here's what's on this branch:
- a preset.js that handles some preset stuff. I'm not really happy using a class for this. A simple global var and a few function should do it, not sure what's cleaner ;
- basically, item presets are pulled from globals.data, then fed into a lookup table so that we can find all presets that apply to a given template item in O(1) ;
- ragfair now creates offers for all items as before, and also for all presets. This enables having operational weapons on the market, all variants (for those who want to try a specific preset), but also the base receivers as before (for those who want to mod from scratch). This should fix #243 ;
- market prices are computed for full weapons ;
- move.js::addItem() now handles preset weapons: if the given template id correspond to a preset, then the whole preset is pulled.
- now that addItem supports it, hideout replaces crafted weapon's template with their corresponding standard preset. As a result, addItem correctly pulls the whole gun, fixing #185 ;

Improvements:

- as you said, ragfair could use a good refactoring.
- It seems that only 2 modules use templates.data.items, and most of the time it's for finding an item: this array could be turned into a dictionary.
- ragfair's assorts are not used at all for presets. It shouldn't be hard to remove these assorts completely, but then idk about modding.

Notes:
I did a few tests, that solution seems pretty fast. I avoided the temptation of caching all templates in memory (only a few ids are kept).
Let me know if you see anything wrong, suggestions, or things to change.