### PR TITLE
Fix for #258 wrong price when buying preset parts

### DIFF
--- a/src/classes/ragfair.js
+++ b/src/classes/ragfair.js
@@ -218,7 +218,7 @@ function createOfferFromBuild(buildItems,response) {
         for (let curItem in items.data) {
             if (curItem === itemFromBuild) {
                 let item = itm_hf.getTemplateItem(itemFromBuild);
-                response.data.offers = response.data.offers.concat(createOffer(curItem, item.Price));
+                response.data.offers = response.data.offers.concat(createOffer(curItem, item.Price, false));
                 break;
             }
         }
@@ -227,12 +227,12 @@ function createOfferFromBuild(buildItems,response) {
     return response
 }
 
-function createOffer(template, price) {
+function createOffer(template, price, usePresets = true) {
     let offerBase = json.parse(json.read(filepaths.ragfair.offer));
     let offers = [];
 
     // Preset
-    if (preset_f.itemPresets.hasPreset(template)) {
+    if (usePresets && preset_f.itemPresets.hasPreset(template)) {
         let presets = preset_f.itemPresets.getPresets(template);
         
         for (let p of presets) {
@@ -257,9 +257,13 @@ function createOffer(template, price) {
     }
 
     // Single item
+    let rubPrice = Math.round(price * settings.gameplay.trading.ragfairMultiplier);
     offerBase._id = template;
     offerBase.items[0]._tpl = template;
-    offerBase.requirements[0].count = Math.round(price * settings.gameplay.trading.ragfairMultiplier);
+    offerBase.requirements[0].count = rubPrice;
+    offerBase.itemsCost = rubPrice;
+    offerBase.requirementsCost = rubPrice;
+    offerBase.summaryCost = rubPrice;
     offers.push(offerBase);
     //offerBase.startTime = utility.getTimestamp() - 1000;
     //offerBase.endTime = utility.getTimestamp() + 43200;


### PR DESCRIPTION
I'm reworking ragfair.js but until it's done, here's a fix.
Disables presets when buying build parts in createOffer().
Sets all offer prices to the actual price.