### PR TITLE
Fix #267 examine preset weapon

### DIFF
--- a/src/classes/preset.js
+++ b/src/classes/preset.js
@@ -56,6 +56,20 @@ class ItemPresets {
 
         return allPresets[0];
     }
+
+    getBaseItemTpl(presetId) {
+        if (this.isPreset(presetId)) {
+            let preset = globals.data.ItemPresets[presetId];
+
+            for (let item of preset._items) {
+                if (preset._parent === item._id) {
+                    return item._tpl;
+                }
+            }
+        }
+
+        return "";
+    }
 }
 
 module.exports.itemPresets = new ItemPresets();

--- a/src/classes/status.js
+++ b/src/classes/status.js
@@ -95,6 +95,10 @@ function examineItem(pmcData, body, sessionID) {
         }
     }
 
+    if (preset_f.itemPresets.isPreset(returned)) {
+        returned = preset_f.itemPresets.getBaseItemTpl(returned);
+    }
+
     // item not found
     if (returned === "") {
         logger.logError("Cannot find proper item. Stopped.");


### PR DESCRIPTION
A fix for #267 
itemPresets can now give back the base item's TPL (given a preset ID), which helps examining preset items.