### PR TITLE
Fix for #294

### DIFF
--- a/src/classes/move.js
+++ b/src/classes/move.js
@@ -360,6 +360,9 @@ function addItem(pmcData, body, output, sessionID, foundInRaid = false) {
         items = globals.data.ItemPresets[body.item_id]._items;
         body.item_id = items[0]._id;
     }
+    else if ("579dc571d53a0658a154fbec" === body.tid) {
+        items = [{_id: body.item_id, _tpl: body.item_id}];
+    }
     else {
         items = trader_f.traderServer.getAssort(body.tid).data.items;
     }

--- a/src/classes/trade.js
+++ b/src/classes/trade.js
@@ -75,7 +75,7 @@ function confirmRagfairTrading(pmcData, body, sessionID) {
         body = {};
         body.Action = "TradingConfirm";
         body.type = "buy_from_trader";
-        body.tid = "54cb57776803fa99248b456e";
+        body.tid = "579dc571d53a0658a154fbec";
         body.item_id = offer.id;
         body.count = offer.count;
         body.scheme_id = 0;


### PR DESCRIPTION
Maybe not the best solution but it should do for now.

This only works because ragfair/fence items have id=tpl. Otherwise I guess we could just bypass the assort cache and read the assort file directly.

Should fix server crash when buying at market and unlock #147 debugging (that may even solve it).